### PR TITLE
Allow setting and getting internal state

### DIFF
--- a/runstats/__init__.py
+++ b/runstats/__init__.py
@@ -4,8 +4,10 @@
 
 try:
     from .fast import Statistics, Regression
+    __compiled__ = True
 except ImportError:
     from .core import Statistics, Regression
+    __compiled__ = False
 
 __title__ = 'runstats'
 __version__ = '1.0.0'

--- a/runstats/core.py
+++ b/runstats/core.py
@@ -6,6 +6,7 @@ Compute Statistics and Regression in a single pass.
 
 from __future__ import division
 
+
 class Statistics(object):
     """Compute statistics in a single pass.
 
@@ -31,6 +32,25 @@ class Statistics(object):
         """Clear Statistics object."""
         self._count = self._eta = self._rho = self._tau = self._phi = 0.0
         self._min = self._max = float('nan')
+
+    def get_state(self):
+        """ Get the internal state of this object
+        """
+        # suppose this estimator has parameters "alpha" and "recursive"
+        return {"count": self._count,
+                "eta": self._eta,
+                "rho": self._rho,
+                "tau": self._tau,
+                "phi": self._phi,
+                "min": self._min,
+                "max": self._max}
+
+    def set_state(self, **parameters):
+        """Set the internal state to the given parameters
+        """
+        for parameter, value in parameters.items():
+            setattr(self, "_" + parameter, value)
+        return self
 
     def __copy__(self):
         """Copy Statistics object."""
@@ -171,6 +191,7 @@ class Statistics(object):
 
         return self
 
+
 class Regression(object):
     """
     Compute simple linear regression in a single pass.
@@ -200,6 +221,27 @@ class Regression(object):
         self._xstats.clear()
         self._ystats.clear()
         self._count = self._sxy = 0.0
+
+    def get_state(self):
+        """ Get the internal state of this object
+        """
+        # suppose this estimator has parameters "alpha" and "recursive"
+        return {"count": self._count,
+                "sxy": self._sxy,
+                "xstats": self._xstats.get_state(),
+                "ystats": self._ystats.get_state()}
+
+    def set_state(self, **parameters):
+        """Set the internal state to the given parameters
+        """
+        for parameter, value in parameters.items():
+            if parameter in ("xstats", "ystats"):
+                stats = Statistics()
+                stats.set_state(**value)
+                setattr(self, "_" + parameter, stats)
+            else:
+                setattr(self, "_" + parameter, value)
+        return self
 
     def __copy__(self):
         """Copy Regression object."""

--- a/runstats/core.py
+++ b/runstats/core.py
@@ -36,7 +36,6 @@ class Statistics(object):
     def get_state(self):
         """ Get the internal state of this object
         """
-        # suppose this estimator has parameters "alpha" and "recursive"
         return {"count": self._count,
                 "eta": self._eta,
                 "rho": self._rho,
@@ -225,7 +224,6 @@ class Regression(object):
     def get_state(self):
         """ Get the internal state of this object
         """
-        # suppose this estimator has parameters "alpha" and "recursive"
         return {"count": self._count,
                 "sxy": self._sxy,
                 "xstats": self._xstats.get_state(),

--- a/runstats/fast.pyx
+++ b/runstats/fast.pyx
@@ -44,7 +44,6 @@ cdef class Statistics(object):
     def get_state(self):
         """ Get the internal state of this object
         """
-        # suppose this estimator has parameters "alpha" and "recursive"
         return {"count": self._count,
                 "eta": self._eta,
                 "rho": self._rho,
@@ -237,7 +236,6 @@ cdef class Regression(object):
     def get_state(self):
         """ Get the internal state of this object
         """
-        # suppose this estimator has parameters "alpha" and "recursive"
         return {"count": self._count,
                 "sxy": self._sxy,
                 "xstats": self._xstats.get_state(),

--- a/runstats/fast.pyx
+++ b/runstats/fast.pyx
@@ -6,6 +6,7 @@ Compute Statistics and Regression in a single pass.
 
 from __future__ import division
 
+
 cdef class Statistics(object):
     """Compute statistics in a single pass.
 
@@ -39,6 +40,25 @@ cdef class Statistics(object):
         """Clear Statistics object."""
         self._count = self._eta = self._rho = self._tau = self._phi = 0.0
         self._min = self._max = float('nan')
+
+    def get_state(self):
+        """ Get the internal state of this object
+        """
+        # suppose this estimator has parameters "alpha" and "recursive"
+        return {"count": self._count,
+                "eta": self._eta,
+                "rho": self._rho,
+                "tau": self._tau,
+                "phi": self._phi,
+                "min": self._min,
+                "max": self._max}
+
+    def set_state(self, **parameters):
+        """Set the internal state to the given parameters
+        """
+        for parameter, value in parameters.items():
+            setattr(self, "_" + parameter, value)
+        return self
 
     def __copy__(self):
         """Copy Statistics object."""
@@ -179,6 +199,7 @@ cdef class Statistics(object):
 
         return self
 
+
 cdef class Regression(object):
     """
     Compute simple linear regression in a single pass.
@@ -212,6 +233,27 @@ cdef class Regression(object):
         self._xstats.clear()
         self._ystats.clear()
         self._count = self._sxy = 0.0
+
+    def get_state(self):
+        """ Get the internal state of this object
+        """
+        # suppose this estimator has parameters "alpha" and "recursive"
+        return {"count": self._count,
+                "sxy": self._sxy,
+                "xstats": self._xstats.get_state(),
+                "ystats": self._ystats.get_state()}
+
+    def set_state(self, **parameters):
+        """Set the internal state to the given parameters
+        """
+        for parameter, value in parameters.items():
+            if parameter in ("xstats", "ystats"):
+                stats = Statistics()
+                stats.set_state(**value)
+                setattr(self, "_" + parameter, stats)
+            else:
+                setattr(self, "_" + parameter, value)
+        return self
 
     def __copy__(self):
         """Copy Regression object."""

--- a/tests/test_runstats.py
+++ b/tests/test_runstats.py
@@ -10,15 +10,19 @@ random.seed(0)
 limit = 1e-2
 count = 1000
 
+
 def mean(values):
     return sum(values) / len(values)
+
 
 def variance(values):
     temp = mean(values)
     return sum((value - temp) ** 2 for value in values) / len(values)
 
+
 def stddev(values):
     return variance(values) ** 0.5
+
 
 def skewness(values):
     temp = mean(values)
@@ -27,6 +31,7 @@ def skewness(values):
                    / len(values)) ** 1.5
     return numerator / denominator
 
+
 def kurtosis(values):
     temp = mean(values)
     numerator = sum((value - temp) ** 4 for value in values) / len(values)
@@ -34,11 +39,13 @@ def kurtosis(values):
     denominator = (sum_diff_2 / len(values)) ** 2
     return (numerator / denominator) - 3
 
+
 def error(value, test):
     return abs((test - value) / value)
 
+
 def test_statistics():
-    alpha = [random.random() for val in range(count)]
+    alpha = [random.random() for _ in range(count)]
 
     alpha_stats = Statistics()
     for val in alpha:
@@ -89,6 +96,7 @@ def test_statistics():
     assert delta_stats.minimum() == min(alpha + beta)
     assert delta_stats.maximum() == max(alpha + beta)
 
+
 def correlation(values):
     sigma_x = sum(xxx for xxx, yyy in values) / len(values)
     sigma_y = sum(yyy for xxx, yyy in values) / len(values)
@@ -96,6 +104,7 @@ def correlation(values):
     sigma_x2 = sum(xxx ** 2 for xxx, yyy in values) / len(values)
     sigma_y2 = sum(yyy ** 2 for xxx, yyy in values) / len(values)
     return (sigma_xy - sigma_x * sigma_y) / (((sigma_x2 - sigma_x ** 2) * (sigma_y2 - sigma_y ** 2)) ** 0.5)
+
 
 def test_regression():
     alpha, beta, rand = 5.0, 10.0, 20.0
@@ -135,6 +144,49 @@ def test_regression():
     assert error(regr.slope(), regr_copy.slope()) < limit
     assert error(regr.intercept(), regr_copy.intercept()) < limit
     assert error(regr.correlation(), regr_copy.correlation()) < limit
+
+
+def test_get_set_state_statistics():
+    tail = -10
+    vals = [random.random() for _ in range(count)]
+    stats = Statistics(vals[:tail])
+    state = stats.get_state()
+    for num in vals[tail:]:
+        stats.push(num)
+    new_stats = Statistics()
+    new_stats.set_state(**state)
+    for num in vals[tail:]:
+        new_stats.push(num)
+    assert stats.mean() == new_stats.mean()
+    assert stats.variance() == new_stats.variance()
+    assert stats.minimum() == new_stats.minimum()
+    assert stats.maximum() == new_stats.maximum()
+    assert stats.kurtosis() == new_stats.kurtosis()
+    assert stats.skewness() == new_stats.skewness()
+
+
+def test_get_set_state_regression():
+    tail = -10
+    alpha, beta, rand = 5.0, 10.0, 20.0
+    points = [(xxx, alpha * xxx + beta + rand * (0.5 - random.random()))
+              for xxx in range(count)]
+    regr = Regression()
+    for xxx, yyy in points[:tail]:
+        regr.push(xxx, yyy)
+
+    state = regr.get_state()
+    for xxx, yyy in points[tail:]:
+        regr.push(xxx, yyy)
+
+    new_regr = Regression()
+    new_regr.set_state(**state)
+    for xxx, yyy in points[tail:]:
+        new_regr.push(xxx, yyy)
+
+    assert regr.slope() == new_regr.slope()
+    assert regr.intercept() == new_regr.intercept()
+    assert regr.correlation() == new_regr.correlation()
+
 
 if __name__ == '__main__':
     import nose

--- a/tests/test_runstats.py
+++ b/tests/test_runstats.py
@@ -5,8 +5,6 @@
 import random
 from runstats import Statistics, Regression
 
-random.seed(0)
-
 limit = 1e-2
 count = 1000
 
@@ -45,6 +43,7 @@ def error(value, test):
 
 
 def test_statistics():
+    random.seed(0)
     alpha = [random.random() for _ in range(count)]
 
     alpha_stats = Statistics()
@@ -66,7 +65,7 @@ def test_statistics():
 
     alpha_stats = Statistics(alpha)
 
-    beta = [random.random() for val in range(count)]
+    beta = [random.random() for _ in range(count)]
 
     beta_stats = Statistics()
 
@@ -107,6 +106,7 @@ def correlation(values):
 
 
 def test_regression():
+    random.seed(21432141)
     alpha, beta, rand = 5.0, 10.0, 20.0
 
     points = [(xxx, alpha * xxx + beta + rand * (0.5 - random.random()))
@@ -147,6 +147,7 @@ def test_regression():
 
 
 def test_get_set_state_statistics():
+    random.seed(0)
     tail = -10
     vals = [random.random() for _ in range(count)]
     stats = Statistics(vals[:tail])
@@ -166,6 +167,7 @@ def test_get_set_state_statistics():
 
 
 def test_get_set_state_regression():
+    random.seed(0)
     tail = -10
     alpha, beta, rand = 5.0, 10.0, 20.0
     points = [(xxx, alpha * xxx + beta + rand * (0.5 - random.random()))

--- a/tests/test_runstats_core.py
+++ b/tests/test_runstats_core.py
@@ -45,7 +45,8 @@ def error(value, test):
 
 
 def test_statistics():
-    alpha = [random.random() for val in range(count)]
+    random.seed(3)
+    alpha = [random.random() for _ in range(count)]
 
     alpha_stats = Statistics()
     for val in alpha:
@@ -66,7 +67,7 @@ def test_statistics():
 
     alpha_stats = Statistics(alpha)
 
-    beta = [random.random() for val in range(count)]
+    beta = [random.random() for _ in range(count)]
 
     beta_stats = Statistics()
 
@@ -107,6 +108,7 @@ def correlation(values):
 
 
 def test_regression():
+    random.seed(21432141)
     alpha, beta, rand = 5.0, 10.0, 20.0
 
     points = [(xxx, alpha * xxx + beta + rand * (0.5 - random.random()))
@@ -147,6 +149,7 @@ def test_regression():
 
 
 def test_get_set_state_statistics():
+    random.seed(0)
     tail = -10
     vals = [random.random() for _ in range(count)]
     stats = Statistics(vals[:tail])
@@ -166,6 +169,7 @@ def test_get_set_state_statistics():
 
 
 def test_get_set_state_regression():
+    random.seed(0)
     tail = -10
     alpha, beta, rand = 5.0, 10.0, 20.0
     points = [(xxx, alpha * xxx + beta + rand * (0.5 - random.random()))

--- a/tests/test_runstats_core.py
+++ b/tests/test_runstats_core.py
@@ -5,7 +5,6 @@
 import random
 from runstats.core import Statistics, Regression
 
-random.seed(0)
 
 limit = 1e-2
 count = 1000


### PR DESCRIPTION
Getting and setting the internal state of the ``Statistics`` and ``Regression`` object in order to resolve issue #4. I renamed the methods to ``get_state`` and ``set_state`` instead of ``get_params`` and ``set_params`` because we are saving the internal state while in Scikit-Learn the parameters are really the initialization parameters. 
As shown in the unit tests those methods allow storing the current state of the aforementioned objects for later usage. 
Some minor PEP8 related changes were also done.