### PR TITLE
Fix problem with summing stats/regs of count 0

### DIFF
--- a/runstats/core.py
+++ b/runstats/core.py
@@ -143,6 +143,8 @@ class Statistics(object):
     def __iadd__(self, that):
         """Add another Statistics object to this one."""
         sum_count = self._count + that._count
+        if sum_count == 0:
+            return self
 
         delta = that._eta - self._eta
         delta2 = delta ** 2
@@ -195,6 +197,7 @@ class Statistics(object):
         self._phi = sum_phi
 
         return self
+
 
 def make_statistics(state):
     """Make Statistics object from state."""
@@ -310,9 +313,12 @@ class Regression(object):
 
     def __iadd__(self, that):
         """Add another Regression object to this one."""
+        sum_count = self._count + that._count
+        if sum_count == 0:
+            return self
+
         sum_xstats = self._xstats + that._xstats
         sum_ystats = self._ystats + that._ystats
-        sum_count = self._count + that._count
 
         deltax = that._xstats.mean() - self._xstats.mean()
         deltay = that._ystats.mean() - self._ystats.mean()
@@ -327,6 +333,7 @@ class Regression(object):
         self._sxy = sum_sxy
 
         return self
+
 
 def make_regression(state):
     """Make Regression object from state."""

--- a/runstats/fast.pyx
+++ b/runstats/fast.pyx
@@ -155,6 +155,8 @@ cdef class Statistics(object):
     def __iadd__(self, that):
         """Add another Statistics object to this one."""
         cdef double sum_count = self._count + that._count
+        if sum_count == 0:
+            return self
 
         cdef double delta = that._eta - self._eta
         cdef double delta2 = delta ** 2
@@ -324,9 +326,12 @@ cdef class Regression(object):
 
     def __iadd__(self, that):
         """Add another Regression object to this one."""
+        sum_count = self._count + that._count
+        if sum_count == 0:
+            return self
+
         sum_xstats = self._xstats + that._xstats
         sum_ystats = self._ystats + that._ystats
-        sum_count = self._count + that._count
 
         deltax = that._xstats.mean() - self._xstats.mean()
         deltay = that._ystats.mean() - self._ystats.mean()

--- a/tests/test_runstats.py
+++ b/tests/test_runstats.py
@@ -284,6 +284,22 @@ def test_equality_regression(Statistics, Regression):
     assert hash(regr1) != hash(regr2)
 
 
+@wrap_core_fast
+def test_sum_stats_count0(Statistics, Regression):
+    stats1 = Statistics()
+    stats2 = Statistics()
+    sumstats = stats1 + stats2
+    assert len(sumstats) == 0
+
+
+@wrap_core_fast
+def test_sum_regr_count0(Statistics, Regression):
+    regr1 = Regression()
+    regr2 = Regression()
+    sumregr = regr1 + regr2
+    assert len(sumregr) == 0
+
+
 if __name__ == '__main__':
     import nose
     nose.run()


### PR DESCRIPTION
Adding two Statistics (and Regression) objects that have no pushed values yet leads to a ZeroDivisionError:
```
In [1]: a = runstats.Statistics()
In [2]: b = runstats.Statistics()
In [3]: a + b
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call last)
<ipython-input-5-f96fb8f649b6> in <module>()
----> 1 a + b
/Users/fwilhelm/Sources/python-runstats/runstats/fast.pyx in runstats.fast.Statistics.__add__ (runstats/fast.c:3496)()
/Users/fwilhelm/Sources/python-runstats/runstats/fast.pyx in runstats.fast.Statistics.__iadd__ (runstats/fast.c:3686)()
ZeroDivisionError: float division by zero
```